### PR TITLE
Add Jenkins Summary widget

### DIFF
--- a/jobs/jenkins_summary.rb
+++ b/jobs/jenkins_summary.rb
@@ -1,0 +1,21 @@
+require './lib/jenkins_client'
+
+JENKINS_SUMMARY_HOST     = ENV.fetch('JENKINS_SUMMARY_HOST')
+JENKINS_SUMMARY_USERNAME = ENV.fetch('JENKINS_SUMMARY_USERNAME')
+JENKINS_SUMMARY_TOKEN    = ENV.fetch('JENKINS_SUMMARY_TOKEN')
+JENKINS_SUMMARY_VIEW     = ENV.fetch('JENKINS_SUMMARY_VIEW', 'All')
+
+SCHEDULER.every '10s', first_in: 0 do
+  jenkins = JenkinsClient.new(JENKINS_SUMMARY_HOST, JENKINS_SUMMARY_USERNAME, JENKINS_SUMMARY_TOKEN)
+  jobs = jenkins.get_jobs(view: JENKINS_SUMMARY_VIEW)
+
+  failing_jobs = -> (j) { j['color'] == 'red' }
+
+  red_jobs_names   = jobs.select(&failing_jobs).map {|j| j['name'] }
+  green_jobs_count = jobs.reject(&failing_jobs).size
+
+  send_event('jenkins-summary', {
+    red: red_jobs_names,
+    green: green_jobs_count
+  })
+end

--- a/lib/jenkins_client.rb
+++ b/lib/jenkins_client.rb
@@ -1,0 +1,30 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+class JenkinsClient
+  def initialize(host, username, token)
+    @host     = host
+    @username = username
+    @token    = token
+  end
+
+  def get_jobs(view:)
+    request("/view/#{view}")['jobs']
+  end
+
+  private
+
+  def request(path)
+    encoded_path = URI.encode(path)
+    uri = URI.parse("#{@host}#{encoded_path}/api/json")
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    req = Net::HTTP::Get.new(uri.request_uri)
+    req.basic_auth(@username, @token)
+
+    JSON.parse(http.request(req).body)
+  end
+end

--- a/widgets/jenkins_summary/jenkins_summary.coffee
+++ b/widgets/jenkins_summary/jenkins_summary.coffee
@@ -1,0 +1,15 @@
+class Dashing.JenkinsSummary extends Dashing.Widget
+  constructor: ->
+    super
+    @_setClass()
+
+  @accessor 'green', Dashing.AnimatedValue
+
+  @accessor 'hasRedJobs', ->
+    @get('red')?.length > 0
+
+  onData: (data) =>
+    @_setClass()
+
+  _setClass: ->
+    $(@get('node')).toggleClass 'failing', @get('hasRedJobs')

--- a/widgets/jenkins_summary/jenkins_summary.html
+++ b/widgets/jenkins_summary/jenkins_summary.html
@@ -1,0 +1,17 @@
+<h1 class="title" data-bind="title"></h1>
+
+<div class="green" data-hideif="hasRedJobs">
+  <h2 data-bind="green"></h2>
+  <h3>All green!</h3>
+</div>
+
+<div class="failing" data-showif="hasRedJobs">
+  <h3>Failing jobs: </h3>
+  <ul>
+    <li data-foreach-item="red">
+      <span class="value" data-bind="item"></span>
+    </li>
+  </ul>
+</div>
+
+<p class="updated-at" data-bind="updatedAtMessage"></p>

--- a/widgets/jenkins_summary/jenkins_summary.scss
+++ b/widgets/jenkins_summary/jenkins_summary.scss
@@ -1,0 +1,14 @@
+$background-color:  #429C6A;
+$background-color-failing: #dc5945;
+
+.widget-jenkins-summary {
+  background-color: $background-color;
+
+  .updated-at {
+    color: rgba(0, 0, 0, 0.3);
+  }
+
+  &.failing {
+    background-color: $background-color-failing;
+  }
+}


### PR DESCRIPTION
This widget displays a summary of a specified Jenkins view. It does not display a single block per job, but only displays the jobs that have failed.

When all jobs are green:

![screen shot 2014-12-27 at 20 10 39](https://cloud.githubusercontent.com/assets/304603/5562102/787ce624-8e04-11e4-8c8d-f7d24f643b10.png)

When there are one or more failures:

![screen shot 2014-12-27 at 20 06 39](https://cloud.githubusercontent.com/assets/304603/5562103/838d1ec6-8e04-11e4-9f2d-d3a08f6181bd.png)
